### PR TITLE
skip installation of aufs-dkms

### DIFF
--- a/docker/tasks/main.yml
+++ b/docker/tasks/main.yml
@@ -34,6 +34,7 @@
     pkg: docker-ce
     state: latest
     update_cache: yes
+    install_recommends: no
 
 - name: Install pip
   apt:


### PR DESCRIPTION
Reference: https://github.com/raspberrypi/linux/issues/3021#issuecomment-508571569

With the latest raspberry pi (buster), support for aufs-dkms has been removed, but docker recommends installing it, even though it's not required. So the installation fails as apt tries to install aufs-dkms. This change fixes this issue by ignoring recommended installs.